### PR TITLE
Add an optional parameter "failonerror".

### DIFF
--- a/tests/MessageTests.php
+++ b/tests/MessageTests.php
@@ -59,4 +59,18 @@ class MessageTests extends \PHPUnit_Framework_TestCase
         $task = new PhingTask;
         $this->assertEquals(get_class($task->createQueue()), 'rcrowe\Hippy\PhingTask');
     }
+
+    /**
+     * @expectedException BuildException
+     */
+    public function testFailOnErrorOn() {
+        $task = new PhingTask;
+        $task->setText('');
+    }
+
+    public function testFailOnErrorOff() {
+        $task = new PhingTask;
+        $task->setFailOnError(false);
+        $task->setText('');
+    }
 }


### PR DESCRIPTION
The intended behavior for this is to be able to rig hipchat so the
build doesn't fail if hipchat is down (as is the case at the moment).
- unit test goodness.
